### PR TITLE
Standardize PHP brace usage across the project

### DIFF
--- a/core/ajax.php
+++ b/core/ajax.php
@@ -18,12 +18,13 @@ class QA_AJAX {
 		$id = $_POST['post_id'];
 		$post_type = get_post_type( $id );
 
-		if ( 'question' == $post_type )
-			the_question_voting( $id );
-		elseif ( 'answer' == $post_type )
-			the_answer_voting( $id );
-		else
-			die( -1 );
+                if ( 'question' == $post_type ) {
+                        the_question_voting( $id );
+                } elseif ( 'answer' == $post_type ) {
+                        the_answer_voting( $id );
+                } else {
+                        die( -1 );
+                }
 		die;
 	}
 

--- a/core/answers.php
+++ b/core/answers.php
@@ -56,8 +56,9 @@ class QA_Answers {
 
     function admin_enqueue_scripts( $hook ) {
         global $post;
-        if ( 'edit.php' != $hook || (isset($post) && $post->post_type != 'answer') )
+        if ( 'edit.php' != $hook || (isset($post) && $post->post_type != 'answer') ) {
             return;
+        }
         wp_enqueue_style('qa-answers-remove-add');
     }
 
@@ -69,8 +70,9 @@ class QA_Answers {
                 'question' => $args['question'],
             ));
 
-            if ( !$question )
+            if ( !$question ) {
                 return array( 'error' => 404 );
+            }
 
             $this->question = reset($question);
 
@@ -88,8 +90,9 @@ class QA_Answers {
 
     // Prevent redirect on paginated answers
     function redirect_canonical( $redirect_url, $requested_url ) {
-        if ( is_singular('question') && is_paged() )
+        if ( is_singular('question') && is_paged() ) {
             return false;
+        }
 
         return $redirect_url;
     }

--- a/core/edit.php
+++ b/core/edit.php
@@ -37,15 +37,17 @@ class QA_Edit {
 		$options = get_option( QA_OPTIONS_NAME );
 		$options = is_array( $options ) ? $options : array();
 		// Check if specific plugin option is requested and return it
-		if ( isset( $key ) && array_key_exists( $key, $options ) )
-		return $options[$key];
-		else
-		return $options;
+                if ( isset( $key ) && array_key_exists( $key, $options ) ) {
+                        return $options[$key];
+                } else {
+                        return $options;
+                }
 	}
 
 	function handle_forms() {
-		if ( !isset( $_REQUEST['_wpnonce'] ) )
-		return;
+                if ( !isset( $_REQUEST['_wpnonce'] ) ) {
+                        return;
+                }
 
 		// Handle deletions
 		if ( isset( $_REQUEST['qa_delete'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'qa_delete' ) ) {
@@ -85,16 +87,20 @@ class QA_Edit {
 	function handle_question_editing() {
 		global $wpdb, $qa_general_settings;
 
-		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'qa_edit' ) )
-		wp_die( __( 'Nonce error: It looks like you don\'t have permission to do that.', QA_TEXTDOMAIN ) );
+                if ( !wp_verify_nonce( $_POST['_wpnonce'], 'qa_edit' ) ) {
+                        wp_die( __( 'Nonce error: It looks like you don\'t have permission to do that.', QA_TEXTDOMAIN ) );
+                }
 
 		// Handle captcha
-		if( $qa_general_settings['captcha'] ) {
-			if( ! session_id() ) session_start();
-			$random = strtoupper($_POST['random']);
-			if( $_SESSION['captcha_random_value'] != md5($random))
-			wp_die( __( 'Characters entered do not match the image.  Please use your browser\'s back button to edit your question.', QA_TEXTDOMAIN ) );
-		}
+                if( $qa_general_settings['captcha'] ) {
+                        if( ! session_id() ) {
+                                session_start();
+                        }
+                        $random = strtoupper($_POST['random']);
+                        if( $_SESSION['captcha_random_value'] != md5($random)) {
+                                wp_die( __( 'Characters entered do not match the image.  Please use your browser\'s back button to edit your question.', QA_TEXTDOMAIN ) );
+                        }
+                }
 		$question_id = (int) $_POST['question_id'];
 
 		$question = array(
@@ -102,8 +108,9 @@ class QA_Edit {
 		'post_content' => trim( $_POST['question_content'] ),
 		);
 
-		if ( empty( $question['post_title'] ) || empty( $question['post_content'] ) )
-		wp_die( __( 'Questions must have both a title and a body. Please use your browser\'s back button to edit your question.', QA_TEXTDOMAIN ) );
+                if ( empty( $question['post_title'] ) || empty( $question['post_content'] ) ) {
+                        wp_die( __( 'Questions must have both a title and a body. Please use your browser\'s back button to edit your question.', QA_TEXTDOMAIN ) );
+                }
 
 		// Check for duplicates
 		if ( !$question_id ) {
@@ -132,16 +139,20 @@ class QA_Edit {
 	function handle_answer_editing() {
 		global $wpdb, $qa_general_settings;
 
-		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'qa_answer' ) )
-		wp_die( __( 'Nonce error: It looks like you don\'t have permission to do that.', QA_TEXTDOMAIN ) );
+                if ( !wp_verify_nonce( $_POST['_wpnonce'], 'qa_answer' ) ) {
+                        wp_die( __( 'Nonce error: It looks like you don\'t have permission to do that.', QA_TEXTDOMAIN ) );
+                }
 
 		// Handle captcha
-		if( $qa_general_settings['captcha'] ) {
-			if( ! session_id() ) @session_start();
-			$random = strtoupper($_POST['random']);
-			if( $_SESSION['captcha_random_value'] != md5($random))
-			wp_die( __( 'Characters entered do not match the image.  Please use your browser\'s back button to edit your answer.', QA_TEXTDOMAIN ) );
-		}
+                if( $qa_general_settings['captcha'] ) {
+                        if( ! session_id() ) {
+                                @session_start();
+                        }
+                        $random = strtoupper($_POST['random']);
+                        if( $_SESSION['captcha_random_value'] != md5($random)) {
+                                wp_die( __( 'Characters entered do not match the image.  Please use your browser\'s back button to edit your answer.', QA_TEXTDOMAIN ) );
+                        }
+                }
 
 		$question_id = (int) $_POST['question_id'];
 		$answer_id = (int) $_POST['answer_id'];
@@ -160,11 +171,13 @@ class QA_Edit {
 		'post_status' => 'publish',
 		);
 
-		if ( empty( $answer['post_parent'] ) )
-		wp_die( __( 'Answer must be associated to a question.', QA_TEXTDOMAIN ) );
+                if ( empty( $answer['post_parent'] ) ) {
+                        wp_die( __( 'Answer must be associated to a question.', QA_TEXTDOMAIN ) );
+                }
 
-		if ( empty( $answer['post_content'] ) )
-		wp_die( __( 'You have to actually write something. Please use your browser\'s back button to edit your answer.', QA_TEXTDOMAIN ) );
+                if ( empty( $answer['post_content'] ) ) {
+                        wp_die( __( 'You have to actually write something. Please use your browser\'s back button to edit your answer.', QA_TEXTDOMAIN ) );
+                }
 
 		// Check for duplicates
 		$dup_id = $wpdb->get_var( $wpdb->prepare( "
@@ -200,8 +213,9 @@ class QA_Edit {
 			}
 
 			// Assign an author, if selected so flooding check can work
-			if ( !is_user_logged_in() && 'assign' == $this->g_settings["method"] )
-			$post_args['post_author'] = $this->g_settings["assigned_to"];
+                        if ( !is_user_logged_in() && 'assign' == $this->g_settings["method"] ) {
+                                $post_args['post_author'] = $this->g_settings["assigned_to"];
+                        }
 
 			// Check for flooding
 			$most_recent = $wpdb->get_var( $wpdb->prepare( "
@@ -213,25 +227,28 @@ class QA_Edit {
 			", get_current_user_id() ) );
 
 			$diff = current_time( 'timestamp' ) - strtotime( $most_recent );
-			if ( !current_user_can('manage_options') && $diff < QA_FLOOD_SECONDS )
-			wp_die( __( 'You are posting too fast. Slow down.', QA_TEXTDOMAIN ) );
+                        if ( !current_user_can('manage_options') && $diff < QA_FLOOD_SECONDS ) {
+                                wp_die( __( 'You are posting too fast. Slow down.', QA_TEXTDOMAIN ) );
+                        }
 
-			$v = get_role( 'visitor' );
-			if ( $v && is_object( $v ) && $v->has_cap( 'immediately_publish_questions' ) )
-			$visitor_can_publish = true;
-			else
-			$visitor_can_publish = false;
+                        $v = get_role( 'visitor' );
+                        if ( $v && is_object( $v ) && $v->has_cap( 'immediately_publish_questions' ) ) {
+                                $visitor_can_publish = true;
+                        } else {
+                                $visitor_can_publish = false;
+                        }
 
 			// Find if post will be saved as pending. New in V1.2
 			$post_args = array_merge( $post_args, $defaults );
-			if ( is_user_logged_in() && current_user_can( 'immediately_publish_questions' ) )
-			$post_args['post_status'] = 'publish';
-			else if ( is_user_logged_in() )
-			$post_args['post_status'] = 'pending';
-			else if ( $visitor_can_publish )
-			$post_args['post_status'] = 'publish';
-			else
-			$post_args['post_status'] = 'pending';
+                        if ( is_user_logged_in() && current_user_can( 'immediately_publish_questions' ) ) {
+                                $post_args['post_status'] = 'publish';
+                        } else if ( is_user_logged_in() ) {
+                                $post_args['post_status'] = 'pending';
+                        } else if ( $visitor_can_publish ) {
+                                $post_args['post_status'] = 'publish';
+                        } else {
+                                $post_args['post_status'] = 'pending';
+                        }
 
 			// Create new post
 			$post_args = apply_filters( 'qa_before_insert_post', $post_args );
@@ -244,9 +261,10 @@ class QA_Edit {
 			// Add category
 			$question_category = apply_filters( 'qa_before_add_category', array( (int) @$_POST['question_cat'] ), $post_args );
 			// Assign a default category if selected so
-			if ( ( empty( $question_category ) || -1 == $question_category[0] )
-			&& isset( $this->g_settings["default_category"] ) && $this->g_settings["default_category"] )
-			$question_category = array( $this->g_settings["default_category"] );
+                        if ( ( empty( $question_category ) || -1 == $question_category[0] )
+                        && isset( $this->g_settings["default_category"] ) && $this->g_settings["default_category"] ) {
+                                $question_category = array( $this->g_settings["default_category"] );
+                        }
 			wp_set_post_terms( $post_id, $question_category, 'question_category' );
 
 			$post = get_post( $post_id );
@@ -260,8 +278,9 @@ class QA_Edit {
 			if ( !is_user_logged_in() ) {
 
 				$login_url = site_url( 'wp-login.php', 'login' );
-				if ( get_option( 'users_can_register' ) )
-				$login_url .= '?action=register';
+                                if ( get_option( 'users_can_register' ) ) {
+                                        $login_url .= '?action=register';
+                                }
 
 				$login_url = apply_filters( 'qa_login_url', $login_url );
 
@@ -284,13 +303,14 @@ class QA_Edit {
 					die;
 				}
 			}
-			else if ( 'publish' != $post->post_status ) {
-				wp_redirect( get_permalink( $this->g_settings["thank_you"] ) );
-				die;
-			}
+                        else if ( 'publish' != $post->post_status ) {
+                                wp_redirect( get_permalink( $this->g_settings["thank_you"] ) );
+                                die;
+                        }
 		} else {
-			if ( !current_user_can( 'edit_post', $post_id ) )
-			die( "Cheatin' uh?" );
+                        if ( !current_user_can( 'edit_post', $post_id ) ) {
+                                die( "Cheatin' uh?" );
+                        }
 
 			// Update post
 			$post_args['ID'] = $post_id;
@@ -371,11 +391,12 @@ class QA_Edit {
 		}
 		$notification_subscriptions = apply_filters( 'qa_notified_users', $notification_subscriptions, $post );
 
-		foreach ( (array)$notification_subscriptions as $uid ) {
-			$user_data = get_userdata($uid);
-			if ( $user_data )
-			wp_mail( $user_data->user_email, $subject_content, str_replace( "TO_USER", $user_data->display_name, $message_content ), $message_headers);
-		}
+                foreach ( (array)$notification_subscriptions as $uid ) {
+                        $user_data = get_userdata($uid);
+                        if ( $user_data ) {
+                                wp_mail( $user_data->user_email, $subject_content, str_replace( "TO_USER", $user_data->display_name, $message_content ), $message_headers);
+                        }
+                }
 
 	}
 
@@ -383,35 +404,38 @@ class QA_Edit {
 	function wp_login( $login ) {
 		$post_id = $this->_get_post_to_claim();
 
-		if ( !$post_id )
-		return;
+                if ( !$post_id ) {
+                        return;
+                }
 
 		$user =  get_user_by('login', $login);
 
-		if ( user_can( $user->ID, 'immediately_publish_questions' ) )
-		wp_update_post( array(
-		'ID' => $post_id,
-		'post_author' => $user->ID,
-		'post_status' => 'publish'
-		) );
-		else
-		wp_update_post( array(
-		'ID' => $post_id,
-		'post_author' => $user->ID
-		) );
+                if ( user_can( $user->ID, 'immediately_publish_questions' ) ) {
+                        wp_update_post( array(
+                        'ID' => $post_id,
+                        'post_author' => $user->ID,
+                        'post_status' => 'publish'
+                        ) );
+                } else {
+                        wp_update_post( array(
+                        'ID' => $post_id,
+                        'post_author' => $user->ID
+                        ) );
+                }
 
 		delete_post_meta( $post_id, '_claim' );
 		setcookie( '_qa_claim', false, time() - 3600, '/' );
 
 		// Check if post is published
 		$post = get_post( $post_id );
-		if ( 'publish' == $post->post_status )
-		wp_safe_redirect( qa_get_url( 'single', $post_id ) );
-		else {
-			if ( !$url = get_permalink( $this->g_settings['thank_you'] ) )
-			$url = site_url();
-			wp_redirect( $url );
-		}
+                if ( 'publish' == $post->post_status ) {
+                        wp_safe_redirect( qa_get_url( 'single', $post_id ) );
+                } else {
+                        if ( !$url = get_permalink( $this->g_settings['thank_you'] ) ) {
+                                $url = site_url();
+                        }
+                        wp_redirect( $url );
+                }
 		die;
 	}
 
@@ -419,8 +443,9 @@ class QA_Edit {
 	function user_register( $user_id ) {
 		$post_id = $this->_get_post_to_claim();
 
-		if ( !$post_id )
-		return;
+                if ( !$post_id ) {
+                        return;
+                }
 
 		wp_set_auth_cookie( $user_id, true, is_ssl() );
 
@@ -429,20 +454,22 @@ class QA_Edit {
 		// Manage question claims here
 		$post_id = $this->_get_post_to_claim();
 
-		if ( !$post_id )
-		return;
+                if ( !$post_id ) {
+                        return;
+                }
 
-		if ( user_can( $user->ID, 'immediately_publish_questions' ) )
-		wp_update_post( array(
-		'ID' => $post_id,
-		'post_author' => $user->ID,
-		'post_status' => 'publish'
-		) );
-		else
-		wp_update_post( array(
-		'ID' => $post_id,
-		'post_author' => $user->ID
-		) );
+                if ( user_can( $user->ID, 'immediately_publish_questions' ) ) {
+                        wp_update_post( array(
+                        'ID' => $post_id,
+                        'post_author' => $user->ID,
+                        'post_status' => 'publish'
+                        ) );
+                } else {
+                        wp_update_post( array(
+                        'ID' => $post_id,
+                        'post_author' => $user->ID
+                        ) );
+                }
 
 		delete_post_meta( $post_id, '_claim' );
 		setcookie( '_qa_claim', false, time() - 3600, '/' );
@@ -452,15 +479,17 @@ class QA_Edit {
 	function registration_redirect( $redirect_to ) {
 		$post_id = $this->_get_post_to_claim();
 
-		if ( !$post_id )
-		return;
+                if ( !$post_id ) {
+                        return;
+                }
 
 		// Check if post is published
 		$post = get_post( $post_id );
-		if ( 'publish' == $post->post_status )
-		$url = qa_get_url( 'single', $post_id );
-		else if ( !$url = get_permalink( $this->g_settings['thank_you'] ) )
-		$url = site_url();
+                if ( 'publish' == $post->post_status ) {
+                        $url = qa_get_url( 'single', $post_id );
+                } else if ( !$url = get_permalink( $this->g_settings['thank_you'] ) ) {
+                        $url = site_url();
+                }
 
 		$url = apply_filters('qa_register_redirect', $url, $post_id );
 		return $url;
@@ -470,11 +499,13 @@ class QA_Edit {
 	function login_message( $msg ) {
 		$post_id = $this->_get_post_to_claim();
 
-		if ( !$post_id )
-		return $msg;
+                if ( !$post_id ) {
+                        return $msg;
+                }
 
-		if ( 'register' != @$_GET['action'] )
-		return $msg;
+                if ( 'register' != @$_GET['action'] ) {
+                        return $msg;
+                }
 
 		$text = sprintf( __( 'To finish posting your %s, please register below. If you already have an account, please <a href="%s">login</a> instead.', QA_TEXTDOMAIN ), get_post_type( $post_id ), wp_login_url() );
 
@@ -482,8 +513,9 @@ class QA_Edit {
 	}
 
 	function _get_post_to_claim() {
-		if ( !isset( $_COOKIE['_qa_claim'] ) )
-		return false;
+                if ( !isset( $_COOKIE['_qa_claim'] ) ) {
+                        return false;
+                }
 
 
 		$posts = get_posts( array(
@@ -493,8 +525,9 @@ class QA_Edit {
 		'post_status' => array( 'publish', 'pending' )
 		) );
 
-		if ( empty( $posts ) )
-		return false;
+                if ( empty( $posts ) ) {
+                        return false;
+                }
 
 		return $posts[0]->ID;
 	}
@@ -503,15 +536,17 @@ class QA_Edit {
 	function handle_slugs( $r, $slug, $post_type ) {
 		global $wp_rewrite;
 
-		if ( 'question' == $post_type )
-		return in_array( $slug, array( 'ask', 'unanswered', 'edit', 'tags', $wp_rewrite->pagination_base ) );
+                if ( 'question' == $post_type ) {
+                        return in_array( $slug, array( 'ask', 'unanswered', 'edit', 'tags', $wp_rewrite->pagination_base ) );
+                }
 
-		return $r;
+                return $r;
 	}
 
 	function transition_post_status( $new_status, $old_status, $post ) {
-		if ( $new_status == $old_status )
-		return;
+                if ( $new_status == $old_status ) {
+                        return;
+                }
 
 		$user_id = get_current_user_id();
 
@@ -587,8 +622,9 @@ class QA_Edit {
 
 		$post = get_post( $post_id );
 
-		if ( 'answer' != $post->post_type )
-		return;
+                if ( 'answer' != $post->post_type ) {
+                        return;
+                }
 
 		$question_id = $post->post_parent;
 
@@ -608,8 +644,9 @@ class QA_Edit {
 	// Handle if questions_category is deleted
 	// since 1.4.2
 	function delete_term( $term, $tt_id, $taxonomy ) {
-		if ( 'question_category' != $term->name || $term->term_id != @$this->g_settings["default_category"] )
-		return;
+                if ( 'question_category' != $term->name || $term->term_id != @$this->g_settings["default_category"] ) {
+                        return;
+                }
 
 		// Set as None as our default category is deleted
 		$this->g_settings['default_category'] = 0;

--- a/core/functions.php
+++ b/core/functions.php
@@ -29,10 +29,11 @@ function is_qa_page( $type = '' ) {
 	}
 
 	// Check if any flags are true
-	if ( empty( $type ) )
-		$result = in_array( true, $flags );
-	else
-		$result = isset( $flags[ $type ] ) && $flags[ $type ];
+        if ( empty( $type ) ) {
+                $result = in_array( true, $flags );
+        } else {
+                $result = isset( $flags[ $type ] ) && $flags[ $type ];
+        }
 	
 	return apply_filters( 'is_qa_page', $result, $type );
 }
@@ -101,8 +102,9 @@ function qa_get_url( $type, $id = 0 ) {
 }
 
 function is_question_answered( $question_id = 0, $type = 'any' ) {
-	if ( !$question_id )
-		$question_id = get_the_ID();
+        if ( !$question_id ) {
+                $question_id = get_the_ID();
+        }
 
 	if ( 'accepted' == $type ) {
 		return apply_filters( 'qa_is_question_answered', get_post_meta( $question_id, '_accepted_answer', true ));
@@ -112,9 +114,11 @@ function is_question_answered( $question_id = 0, $type = 'any' ) {
 }
 
 function get_answer_count( $question_id ) {
-	$count = (int)get_post_meta( $question_id, '_answer_count', true );
+        $count = (int)get_post_meta( $question_id, '_answer_count', true );
 
-	if($count < 0) update_post_meta( $question_id, '_answer_count', 0);
+        if($count < 0) {
+                update_post_meta( $question_id, '_answer_count', 0);
+        }
 
 	return $count;
 }
@@ -183,24 +187,29 @@ function _qa_html( $tag ) {
  */
 	function qa_update_14() {
 		$version = get_option('qa_installed_version');
-		if ( $version == QA_VERSION )
+		if ( $version == QA_VERSION ) {
 			return;
+		}
+
 
 		// Just update version number if theme is already supported
-		if ( strpos( qa_supported_themes(), get_template() ) !== false )
+		if ( strpos( qa_supported_themes(), get_template() ) !== false ) {
 			$supported_theme = true;
-		else
+		} else {
 			$supported_theme = false;
+		}
 
-		if ( !$options = get_option( QA_OPTIONS_NAME ) )
+		if ( !$options = get_option( QA_OPTIONS_NAME ) ) {
 			$options = array();
+		}
 
 		$changed = false;
-		if ( !isset( $options["general_settings"]["page_layout"] ) ) {
-			if ( isset( $options["general_settings"]["full_width"] ) && $options["general_settings"]["full_width"] )
-				$options["general_settings"]["page_layout"] = 'content';
-			else
-				$options["general_settings"]["page_layout"] = 'content-sidebar';
+                if ( !isset( $options["general_settings"]["page_layout"] ) ) {
+                        if ( isset( $options["general_settings"]["full_width"] ) && $options["general_settings"]["full_width"] ) {
+                                $options["general_settings"]["page_layout"] = 'content';
+                        } else {
+                                $options["general_settings"]["page_layout"] = 'content-sidebar';
+                        }
 
 			unset( $options["general_settings"]["full_width"] );
 			$changed = true;

--- a/core/subscriptions.php
+++ b/core/subscriptions.php
@@ -7,13 +7,15 @@ class QA_Subscriptions {
 		add_action( 'transition_post_status', array( &$this, 'notify' ), 10, 3 );
 	}
 
-	function get_link( $id, $subscribe_text, $unsubscribe_text ) {
-		if ( !is_user_logged_in() )
-			return;
+        function get_link( $id, $subscribe_text, $unsubscribe_text ) {
+                if ( !is_user_logged_in() ) {
+                        return;
+                }
 
 		// Question authors are automatically subscribed
-		if ( get_current_user_id() == get_post_field( 'post_author', $id ) )
-			return;
+                if ( get_current_user_id() == get_post_field( 'post_author', $id ) ) {
+                        return;
+                }
 
 		$subscribers = get_post_meta( $id, '_sub' );
 
@@ -32,32 +34,38 @@ class QA_Subscriptions {
 		return _qa_html( 'a', $attr, $subscribed ? $unsubscribe_text : $subscribe_text );
 	}
 
-	function handle_subs() {
-		if ( !is_qa_page( 'single' ) )
-			return;
+        function handle_subs() {
+                if ( !is_qa_page( 'single' ) ) {
+                        return;
+                }
 
-		if ( !is_user_logged_in() )
-			return;
+                if ( !is_user_logged_in() ) {
+                        return;
+                }
 
-		if ( !isset( $_GET['_wpnonce'] ) || !wp_verify_nonce( $_GET['_wpnonce'], 'qa_sub' ) )
-			return;
+                if ( !isset( $_GET['_wpnonce'] ) || !wp_verify_nonce( $_GET['_wpnonce'], 'qa_sub' ) ) {
+                        return;
+                }
 
-		// Question authors are automatically subscribed
-		if ( get_current_user_id() == get_post_field( 'post_author', get_queried_object_id() ) )
-			return false;
+                // Question authors are automatically subscribed
+                if ( get_current_user_id() == get_post_field( 'post_author', get_queried_object_id() ) ) {
+                        return false;
+                }
 
-		if ( $_GET['qa_sub'] )
-			add_post_meta( get_queried_object_id(), '_sub', get_current_user_id() );
-		else
-			delete_post_meta( get_queried_object_id(), '_sub', get_current_user_id() );
+                if ( $_GET['qa_sub'] ) {
+                        add_post_meta( get_queried_object_id(), '_sub', get_current_user_id() );
+                } else {
+                        delete_post_meta( get_queried_object_id(), '_sub', get_current_user_id() );
+                }
 	}
 
 	// TODO: use wp-cron
 	function notify( $new_status, $old_status, $post ) {
 		global $current_site;
 
-		if ( 'answer' != $post->post_type || 'publish' != $new_status || $new_status == $old_status )
-			return;
+                if ( 'answer' != $post->post_type || 'publish' != $new_status || $new_status == $old_status ) {
+                        return;
+                }
 
 		$author = get_userdata( $post->post_author );
 
@@ -65,8 +73,9 @@ class QA_Subscriptions {
 		$question = get_post($question_id);
 
 		$subscribers = get_post_meta( $question_id, '_sub' );
-		if ( !in_array( $question->post_author, $subscribers ) )
-			$subscribers[] = $question->post_author; // Notify question author too
+                if ( !in_array( $question->post_author, $subscribers ) ) {
+                        $subscribers[] = $question->post_author; // Notify question author too
+                }
 
 		if( get_option('qa_cc_admin') )	{
 			$admin_ids = new WP_User_Query( array('role' => 'administrator', 'fields' => 'ID') );

--- a/core/template-tags.php
+++ b/core/template-tags.php
@@ -72,8 +72,9 @@ function the_qa_menu() {
 }
 
 function get_the_qa_error_notice() {
-	if ( !isset( $_GET[ 'qa_error' ] ) )
-		return;
+        if ( !isset( $_GET[ 'qa_error' ] ) ) {
+                return;
+        }
 	$out = '';
 	$out .= '<div id="qa-error-notice">';
 	$out .= __( 'An error has occured while processing your submission.', QA_TEXTDOMAIN );
@@ -101,11 +102,13 @@ function the_qa_search_form() {
 
 function get_the_qa_pagination( $query = null ) {
 
-	if ( is_null( $query ) )
-		$query = $GLOBALS[ 'wp_query' ];
+        if ( is_null( $query ) ) {
+                $query = $GLOBALS[ 'wp_query' ];
+        }
 
-	if ( $query->max_num_pages <= 1 )
-		return;
+        if ( $query->max_num_pages <= 1 ) {
+                return;
+        }
 
 	$out = '';
 
@@ -118,30 +121,37 @@ function get_the_qa_pagination( $query = null ) {
 
 	$out .= '<div class="qa-pagination">';
 
-	if ( $current_page > 1 )
-		$out .= get_qa_single_page_link( $query, $current_page - 1, __( 'prev', QA_TEXTDOMAIN ), 'prev' );
+        if ( $current_page > 1 ) {
+                $out .= get_qa_single_page_link( $query, $current_page - 1, __( 'prev', QA_TEXTDOMAIN ), 'prev' );
+        }
 
-	if ( $range_start > 1 )
-		$out .= get_qa_single_page_link( $query, 1 );
+        if ( $range_start > 1 ) {
+                $out .= get_qa_single_page_link( $query, 1 );
+        }
 
-	if ( $range_start > $padding )
-		$out .= '<span class="dots">...</span>';
+        if ( $range_start > $padding ) {
+                $out .= '<span class="dots">...</span>';
+        }
 
 	foreach ( range( $range_start, $range_finish ) as $num ) {
-		if ( $num == $current_page )
-			$out .= _qa_html( 'span', array( 'class' => 'current' ), number_format_i18n( $num ) );
-		else
-			$out .= get_qa_single_page_link( $query, $num );
-	}
+                if ( $num == $current_page ) {
+                        $out .= _qa_html( 'span', array( 'class' => 'current' ), number_format_i18n( $num ) );
+                } else {
+                        $out .= get_qa_single_page_link( $query, $num );
+                }
+        }
 
-	if ( $range_finish + $padding <= $total_pages )
-		$out .= '<span class="dots">...</span>';
+        if ( $range_finish + $padding <= $total_pages ) {
+                $out .= '<span class="dots">...</span>';
+        }
 
-	if ( $range_finish < $total_pages )
-		$out .= get_qa_single_page_link( $query, $total_pages );
+        if ( $range_finish < $total_pages ) {
+                $out .= get_qa_single_page_link( $query, $total_pages );
+        }
 
-	if ( $current_page < $total_pages )
-		$out .= get_qa_single_page_link( $query, $current_page + 1, __( 'next', QA_TEXTDOMAIN ), 'next' );
+        if ( $current_page < $total_pages ) {
+                $out .= get_qa_single_page_link( $query, $current_page + 1, __( 'next', QA_TEXTDOMAIN ), 'next' );
+        }
 
 	$out .= '</div>';
 
@@ -153,13 +163,15 @@ function the_qa_pagination( $query = null ) {
 }
 
 function get_qa_single_page_link( $query, $num, $title = '', $class = '' ) {
-	if ( !$title )
-		$title = number_format_i18n( $num );
+        if ( !$title ) {
+                $title = number_format_i18n( $num );
+        }
 
 	$args = array( 'href' => get_pagenum_link( $num ) );
 
-	if ( $class )
-		$args[ 'class' ] = $class;
+        if ( $class ) {
+                $args[ 'class' ] = $class;
+        }
 
 	return apply_filters( 'qa_single_page_link', _qa_html( 'a', $args, $title ) );
 }
@@ -175,10 +187,11 @@ function get_the_qa_time( $id ) {
 
 	$time_diff = time() - $time;
 
-	if ( $time_diff > 0 && $time_diff < 24 * 60 * 60 )
+	if ( $time_diff > 0 && $time_diff < 24 * 60 * 60 ) {
 		$h_time	 = sprintf( __( '%s ago', QA_TEXTDOMAIN ), human_time_diff( $time ) );
-	else
+	} else {
 		$h_time	 = mysql2date( get_option( 'date_format' ), $post->post_date );
+	}
 
 	$h_time = apply_filters( 'qa_time', $h_time, $time );
 	return '<span class="qa-timediff">' . $h_time . '</span>';
@@ -229,8 +242,9 @@ function get_the_qa_action_links( $id ) {
 	foreach ( $links as $type => $title ) {
 		if ( 'flag' == $type ) {
 			$flag_link		 = '<a name="qa_report" href="javascript:void(0)" onClick="javascript:document.getElementById(\'qa_flag_form_' . $id . '\').style.display=\'block\';" >' . $title . '</a>';
-			if ( isset( $_GET[ 'flag_received' ] ) )
-				$links[ 'flag' ] = '<span style="color:green">' . __( 'Your report has been received.', QA_TEXTDOMAIN ) . '</span>';
+                        if ( isset( $_GET[ 'flag_received' ] ) ) {
+                                $links[ 'flag' ] = '<span style="color:green">' . __( 'Your report has been received.', QA_TEXTDOMAIN ) . '</span>';
+                        }
 			else if ( isset( $_GET[ 'no_reason' ] ) ) {
 				$links[ 'flag' ] = $flag_link . " " . '<span style="color:red">' . __( 'Please select a reason for reporting.', QA_TEXTDOMAIN ) . '</span>';
 				$show_form		 = true;
@@ -241,16 +255,18 @@ function get_the_qa_action_links( $id ) {
 				$links[ 'flag' ] = $flag_link;
 				$show_form		 = true;
 			}
-		} else
-			$links[ $type ] = _qa_html( 'a', array( 'href' => qa_get_url( $type, $id ) ), $title );
+                        } else {
+                                $links[ $type ] = _qa_html( 'a', array( 'href' => qa_get_url( $type, $id ) ), $title );
+                        }
 	}
 
 	$out = '';
 
 	$out .= '<div class="qa-action-links">';
 	$out .= implode( ' | ', $links );
-	if ( $show_form )
-		$out .= the_qa_flag_form( $id );
+        if ( $show_form ) {
+                $out .= the_qa_flag_form( $id );
+        }
 	$out .= '</div>';
 
 	return $out;
@@ -343,21 +359,25 @@ function the_qa_user_rep( $user_id ) {
   -------------------------------------------------------------- */
 
 function the_question_link( $question_id = 0 ) {
-	global $post;
-	if ( !$question_id )
-		$question_id = $post->ID;
-	if ( !$question_id )
-		$question_id = get_the_ID();
+        global $post;
+        if ( !$question_id ) {
+                $question_id = $post->ID;
+        }
+        if ( !$question_id ) {
+                $question_id = get_the_ID();
+        }
 
 	echo get_question_link( $question_id );
 }
 
 function get_question_link( $question_id = 0 ) {
-	global $post;
-	if ( !$question_id )
-		$question_id = $post->ID;
-	if ( !$question_id )
-		$question_id = get_the_ID();
+        global $post;
+        if ( !$question_id ) {
+                $question_id = $post->ID;
+        }
+        if ( !$question_id ) {
+                $question_id = get_the_ID();
+        }
 
 	if ( !isset( $post ) ) {
 		$post = get_post( $question_id );
@@ -367,11 +387,13 @@ function get_question_link( $question_id = 0 ) {
 }
 
 function get_the_question_score( $question_id = 0, $label = true, $count_class = 'mini-count' ) {
-	global $post;
-	if ( !$question_id )
-		$question_id = $post->ID;
-	if ( !$question_id )
-		$question_id = get_the_ID();
+        global $post;
+        if ( !$question_id ) {
+                $question_id = $post->ID;
+        }
+        if ( !$question_id ) {
+                $question_id = get_the_ID();
+        }
 
 	list( $up, $down ) = qa_get_votes( $question_id );
 
@@ -393,10 +415,11 @@ function the_question_score( $question_id = 0, $label = true, $count_class = 'mi
 }
 
 function get_the_question_voting( $question_id = 0 ) {
-	global $_qa_core;
+        global $_qa_core;
 
-	if ( !$question_id )
-		$question_id = get_the_ID();
+        if ( !$question_id ) {
+                $question_id = get_the_ID();
+        }
 
 	list( $up, $down, $current ) = qa_get_votes( $question_id );
 
@@ -505,17 +528,19 @@ function the_answer_accepted( $answer_id ) {
 
 function get_the_question_status( $question_id = 0, $label = true, $count_class = 'mini-count' ) {
 	global $post;
-	if ( !$question_id )
+	if ( !$question_id ) {
 		$question_id = $post->ID;
+	}
 
 	$count = get_answer_count( $question_id );
 
-	if ( get_post_meta( $question_id, '_accepted_answer', true ) )
+	if ( get_post_meta( $question_id, '_accepted_answer', true ) ) {
 		$status	 = 'answered-accepted';
-	elseif ( $count > 0 )
+	} elseif ( $count > 0 ) {
 		$status	 = 'answered';
-	else
+	} else {
 		$status	 = 'unanswered';
+	}
 
 	$status = apply_filters( 'qa_question_status', $status );
 

--- a/core/votes.php
+++ b/core/votes.php
@@ -11,8 +11,9 @@ class QA_Votes {
 		add_action( 'transition_post_status', array( &$this, 'update_reps' ), 10, 3 );
 		add_action( 'bp_before_member_header_meta', array( &$this, 'bp_before_member_header_meta' ), 10, 3 );
 
-		if ( !is_admin() )
-			add_filter( 'posts_clauses', array( &$this, 'posts_clauses' ), 10, 2 );
+                if ( !is_admin() ) {
+                        add_filter( 'posts_clauses', array( &$this, 'posts_clauses' ), 10, 2 );
+                }
 	}
 
 	function bp_before_member_header_meta( $user_id = 0, $user_nicename = '', $args = array() ) {
@@ -51,10 +52,11 @@ class QA_Votes {
 			'class' => "vote-$vote_type-" . ( $voted ? 'on' : 'off' )
 		);
 
-		if ( !is_user_logged_in() )
-			$input_attr['data-msg'] = 'login';
-		elseif ( get_post_field( 'post_author', $id ) == get_current_user_id() )
-			$input_attr['data-msg'] = 'own';
+                if ( !is_user_logged_in() ) {
+                        $input_attr['data-msg'] = 'login';
+                } elseif ( get_post_field( 'post_author', $id ) == get_current_user_id() ) {
+                        $input_attr['data-msg'] = 'own';
+                }
 
 		ob_start();
 ?>
@@ -84,12 +86,14 @@ class QA_Votes {
 		$user_id = get_current_user_id();
 
 		// Don't allow votes on one's own content
-		if ( $author == $user_id )
-			return false;
+                if ( $author == $user_id ) {
+                        return false;
+                }
 
-		// Check capability
-		if ( !current_user_can( 'read', $id ) )
-			return;
+                // Check capability
+                if ( !current_user_can( 'read', $id ) ) {
+                        return;
+                }
 
 		$this->remove( $id, false );
 
@@ -135,12 +139,13 @@ class QA_Votes {
 
 		$user_id = get_current_user_id();
 
-		if ( in_array( $user_id, $up ) )
-			$current = 'up';
-		elseif ( in_array( $user_id, $down ) )
-			$current = 'down';
-		else
-			$current = false;
+                if ( in_array( $user_id, $up ) ) {
+                        $current = 'up';
+                } elseif ( in_array( $user_id, $down ) ) {
+                        $current = 'down';
+                } else {
+                        $current = false;
+                }
 
 		return array( count( $up ), count( $down ), $current );
 	}
@@ -153,8 +158,9 @@ class QA_Votes {
 
 		$post_types = array_intersect( (array) $wp_query->get( 'post_type' ), array( 'question', 'answer' ) );
 
-		if ( empty( $post_types ) || 'none' == $wp_query->get('qa_count') )
-			return $clauses;
+                if ( empty( $post_types ) || 'none' == $wp_query->get('qa_count') ) {
+                        return $clauses;
+                }
 
 		$clauses['fields'] .= ", COUNT(up.meta_value) - COUNT(down.meta_value) AS qa_score";
 		$clauses['join'] .= "
@@ -163,8 +169,9 @@ class QA_Votes {
 		";
 		$clauses['groupby'] = "$wpdb->posts.ID";
 
-		if ( isset( $wp_query->query['orderby'] ) && 'qa_score' == $wp_query->query['orderby'] )
-			$clauses['orderby'] = "qa_score DESC, post_date ASC";
+                if ( isset( $wp_query->query['orderby'] ) && 'qa_score' == $wp_query->query['orderby'] ) {
+                        $clauses['orderby'] = "qa_score DESC, post_date ASC";
+                }
 
 		return $clauses;
 	}
@@ -173,31 +180,36 @@ class QA_Votes {
 	 * Handle voting and unvoting.
 	 */
 	function handle_voting() {
-		if ( !isset( $_POST['action'] ) || 'qa_vote' != $_POST['action'] )
-			return;
+                if ( !isset( $_POST['action'] ) || 'qa_vote' != $_POST['action'] ) {
+                        return;
+                }
 
-		if ( !isset( $_POST['_wpnonce'] ) || !wp_verify_nonce( $_POST['_wpnonce'], 'qa_vote' ) )
-			return;
+                if ( !isset( $_POST['_wpnonce'] ) || !wp_verify_nonce( $_POST['_wpnonce'], 'qa_vote' ) ) {
+                        return;
+                }
 
 		$id = $_POST['post_id'];
 
 		$vote_type = $_POST['vote_type'];
 
-		if ( 'undo' == $vote_type )
-			$this->remove( $id );
-		else
-			$this->add( $id, $vote_type );
+                if ( 'undo' == $vote_type ) {
+                        $this->remove( $id );
+                } else {
+                        $this->add( $id, $vote_type );
+                }
 	}
 
 	/**
 	 * Handle accepting answers.
 	 */
 	function handle_accepting() {
-		if ( !isset( $_POST['action'] ) || 'qa_accept' != $_POST['action'] )
-			return;
+                if ( !isset( $_POST['action'] ) || 'qa_accept' != $_POST['action'] ) {
+                        return;
+                }
 
-		if ( !isset( $_POST['_wpnonce'] ) || !wp_verify_nonce( $_POST['_wpnonce'], 'qa_accept' ) )
-			return;
+                if ( !isset( $_POST['_wpnonce'] ) || !wp_verify_nonce( $_POST['_wpnonce'], 'qa_accept' ) ) {
+                        return;
+                }
 
 		$answer_id = (int) $_POST['answer_id'];
 
@@ -217,11 +229,12 @@ class QA_Votes {
 	 * Update user reps when a post is unpublished.
 	 */
 	function update_reps( $new_status, $old_status, $post ) {
-		if (
-			!in_array( $post->post_type, array( 'question', 'answer' ) )
-			|| 'publish' != $old_status || $new_status == $old_status
-		)
-			return;
+                if (
+                        !in_array( $post->post_type, array( 'question', 'answer' ) )
+                        || 'publish' != $old_status || $new_status == $old_status
+                ) {
+                        return;
+                }
 
 		$this->update_user_rep( $post->post_author );
 

--- a/tests.php
+++ b/tests.php
@@ -7,8 +7,9 @@
 function test_rewrites() {
 	global $pagenow;
 	
-	if ( 'index.php' != $pagenow )
+	if ( 'index.php' != $pagenow ) {
 		return;
+	}
 
 	$archives = array(
 		qa_get_url( 'archive' ),
@@ -16,8 +17,9 @@ function test_rewrites() {
 	);
 
 	$tag_id = (int) reset( get_terms( 'question_tag', array( 'fields' => 'ids' ) ) );
-	if ( $tag_id )
+	if ( $tag_id ) {
 		$archives[] = qa_get_url( 'tag', $tag_id );
+	}
 
 	$urls = array(
 		qa_get_url( 'ask' )
@@ -54,8 +56,9 @@ add_action('admin_notices', 'test_rewrites');
 
 function test_templates() {
 	foreach ( array( 'ask', 'edit', 'single', 'archive', 'tag', 'category' ) as $type ) {
-		if ( is_qa_page( $type ) )
+		if ( is_qa_page( $type ) ) {
 			echo( "<pre>$type: true\n</pre>" );
+		}
 	}
 }
 #add_action( 'template_redirect', 'test_templates' );


### PR DESCRIPTION
## Summary
- wrap single-line PHP conditionals with braces across the plugin core for consistent block structure
- align the legacy test helper with the new braced style

## Testing
- php -l core/ajax.php core/answers.php core/edit.php core/functions.php core/subscriptions.php core/template-tags.php core/votes.php tests.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe6a589088323a335ee9cb210e8b2