### PR TITLE
Fix answer form visibility on question pages

### DIFF
--- a/core/template-tags.php
+++ b/core/template-tags.php
@@ -718,21 +718,21 @@ function the_answer_list() {
 }
 
 function get_the_answer_form() {
-	global $wp, $wp_query, $wp_version, $qa_general_settings, $post;
-	$user_id = get_current_user_id();
+        global $wp, $wp_query, $wp_version, $qa_general_settings, $post;
+        $user_id = get_current_user_id();
+        $out     = '';
 
-	if ( isset( $wp->query_vars[ 'qa_edit' ] ) ) {
-		$post = get_post( (int) $wp->query_vars[ 'qa_edit' ] );
-	} else {
-		$out .= '<p>' . __( 'You are not allowed to add answers!', QA_TEXTDOMAIN ) . '</p>';
-		return;
-	}
+        if ( isset( $wp->query_vars[ 'qa_edit' ] ) ) {
+                $post = get_post( (int) $wp->query_vars[ 'qa_edit' ] );
 
-	if ( post_password_required( $post ) ) {
-		return;
-	}
+                if ( ! $post ) {
+                        return;
+                }
+        }
 
-	$out = '';
+        if ( post_password_required( $post ) ) {
+                return;
+        }
 
 	if ( isset( $wp->query_vars[ 'qa_edit' ] ) ) {
 		$answer = $post;


### PR DESCRIPTION
## Summary
- ensure the answer form renders on question pages by removing an incorrect early return when not editing an answer
- guard against invalid answer IDs when loading the editor

## Testing
- php -l core/template-tags.php

------
https://chatgpt.com/codex/tasks/task_e_68cd5cff942483238a04bca7f1466377